### PR TITLE
Update inconsistent --apiPath on Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Requests require the following variables to be set:
 * `{{PORT}}` defaults to `443`
 * `{{%s_API_BASE}}`
     * `%s` will be the name of the service, uppercased and underscored.
-    * When `--apiBase` is provided it will be used as the value of the variable.
+    * When `--apiPath` is provided it will be used as the value of the variable.
 
 Overrides and non-default options should be set in an [Environment](https://www.getpostman.com/docs/v6/postman/environments_and_globals/manage_environments).
 


### PR DESCRIPTION
## Before this PR
The documentation is referencing a configuration --apiBase when the correct is --apiPath.
The source code of that configuration that confirms it can be found here:
https://github.com/palantir/conjure-postman/blob/f00b53fe4e5b11ba97579429c211ac7bdccd3711/conjure-postman/src/main/java/com/palantir/conjure/postman/cli/CliConfiguration.java

## After this PR
==COMMIT_MSG==
updated documentation to be consistent with configuration implementation
==COMMIT_MSG==

## Possible downsides?
No downsides.

