### PR TITLE
Fix broken link to Postman Collections docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 conjure-postman
 ------------
-_Generate [Postman](https://www.getpostman.com/) [Collections](https://www.getpostman.com/docs/v6/postman/collections/intro_to_collections) for interacting with [Conjure](https://github.com/palantir/conjure) defined APIs._
+_Generate [Postman](https://www.getpostman.com/) [Collections](https://learning.postman.com/docs/collections/collections-overview/) for interacting with [Conjure](https://github.com/palantir/conjure) defined APIs._
 
 
 ## Usage

--- a/changelog/@unreleased/pr-557.v2.yml
+++ b/changelog/@unreleased/pr-557.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix broken link to Postman Collections docs in README
+  links:
+  - https://github.com/palantir/conjure-postman/pull/557


### PR DESCRIPTION
## Before this PR
README points to a broken link: https://www.getpostman.com/docs/v6/postman/collections/intro_to_collections

## After this PR
==COMMIT_MSG==
Fix broken link to Postman Collections docs in README
==COMMIT_MSG==

## Possible downsides?
None known

